### PR TITLE
fix return value

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2378,7 +2378,7 @@ func (kl *Kubelet) matchesNodeSelector(pod *api.Pod) bool {
 	node, err := kl.GetNode()
 	if err != nil {
 		glog.Errorf("error getting node: %v", err)
-		return true
+		return false
 	}
 	return predicates.PodMatchesNodeLabels(pod, node)
 }


### PR DESCRIPTION
// matchesNodeSelector returns true if pod matches node's labels.
Whether this return value should be false?
